### PR TITLE
font and small css fix/hack

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
 	<!-- Stylesheets
 	============================================= -->
-	<link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400italic,600,700,900|Playfair+Display:400,700" rel="stylesheet" type="text/css" />
+	<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400italic,600,700,900|Playfair+Display:400,700" rel="stylesheet" type="text/css" />
 	<link rel="stylesheet" href="css/bootstrap.css" type="text/css" />
 	<link rel="stylesheet" href="style.css" type="text/css" />
 	<link rel="stylesheet" href="css/dark.css" type="text/css" />

--- a/style.css
+++ b/style.css
@@ -7447,7 +7447,7 @@ body:not(.device-touch) .button.button-full strong {
 
 .feature-box .fbox-icon {
 	display: block;
-	position: absolute;
+	/* position: absolute; */
 	width: 64px;
 	height: 64px;
 	top: 0;


### PR DESCRIPTION
Hi Howie,

I have done two things in this pull request:

1. added an https link to download the google fonts. This is because most browsers won't let you download resources from both http and https sites at the same domain (or something like that) and it was giving the error in the console. You probably wouldn't see this if you are developing locally because the site will be http locally in most cases.

2. I played around a bit with the css for those f-box icons, and found that getting rid of the rule given them position: absolute seemed to correct the overlapping without messing anything else up. I tried it in a few different screen sizes and it seems to work OK, but to be honest I haven't really given it a thorough testing yet. It should probably be more closely evaluated to determine what else that change might affect. However, I suspect it won't affect anything else. 

Feel free to not accept this pull request or to pick it apart to take what you want (or just make the changes on our own). I am just trying to get more comfortable using the different git features.

Again, you can see these changes in action at my fork of the site, https://rpvnwnkl.github.io/revisedportfolio

Best,
Matt